### PR TITLE
meson: Make demo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ To install, use `ninja install`
 ninja install -C builddir
 ```
 
-To see a demo app, run:
+You can optionally build and run a demo app:
 
 ```bash
-./build/examples/example
+meson configure builddir -Ddemo=true
+ninja -C builddir
+./builddir/examples/example
 ```

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,10 @@ libchcase_deps = [
 ]
 
 subdir('lib')
-subdir('examples')
+
+if get_option('demo')
+    subdir('examples')
+endif
 
 if get_option('doc')
     doc_outdir = 'docs'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('doc', type: 'boolean', value: false, description: 'Whether to generate valadoc')
+option('demo', type: 'boolean', value: false, description: 'Whether to build demo app')


### PR DESCRIPTION
We don't need this if the project is used as a library in another project