### PR TITLE
feat: Move include dir to subdir

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -10,13 +10,15 @@ sources = files(
   'Converter.vala',
 )
 
+include_dir = get_option('prefix') / get_option('includedir') / meson.project_name()
+
 chcase_lib = library(
   'chcase',
   sources,
   dependencies: libchcase_deps,
   vala_header: 'chcase.h',
   install: true,
-  install_dir: [true, true, true],
+  install_dir: [true, include_dir, true, true],
 )
 
 install_data(

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -18,7 +18,7 @@ chcase_lib = library(
   dependencies: libchcase_deps,
   vala_header: 'chcase.h',
   install: true,
-  install_dir: [true, include_dir, true, true],
+  install_dir: [true, include_dir, true],
 )
 
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('chcase',
   'vala', 'c',
-  version: '2.4.0',
+  version: '3.0.0',
   meson_version: '>= 0.56.0',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('chcase',
   'vala', 'c',
-  version: '3.0.0',
+  version: '3.0.0-alpha.1',
   meson_version: '>= 0.56.0',
 )
 


### PR DESCRIPTION
The pkgconfig flag already declares `-I/usr/include/chcase` so let's use that.

```
ryo@fedora-host:~/work/ryonakano/konbucase (feature/port-to-c *)$ pkg-config chcase --cflags
-I/usr/include/chcase -DWITH_GZFILEOP -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -pthread
ryo@fedora-host:~/work/ryonakano/konbucase (feature/port-to-c *)$
```
