### PR TITLE
fix: Remove pkgconfig include subdir

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -34,7 +34,6 @@ chcase_pc = pkgconfig.generate(
   chcase_lib,
   name: 'chcase',
   requires: libchcase_deps,
-  subdirs: ['chcase'],
   description: 'A small library to convert case of a given string',
   version: meson.project_version(),
   url: 'https://github.com/ryonakano/chcase',

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('chcase',
   'vala', 'c',
-  version: '3.0.0-alpha.3',
+  version: '3.0.0-alpha.4',
   meson_version: '>= 0.56.0',
 )
 


### PR DESCRIPTION
Fixes the following errors when building an app that uses chcase with `-Werror=missing-include-dirs`:

```
[39/41] Compiling C object src/com.github.ryonakano.konbucase.Devel.p/widget_kc-text-area.c.o
FAILED: [code=1] src/com.github.ryonakano.konbucase.Devel.p/widget_kc-text-area.c.o
ccache cc -Isrc/com.github.ryonakano.konbucase.Devel.p -Isrc -I../src -Isrc/model -I../src/model -Isrc/util -I../src/util -Isrc/view -I../src/view -Isrc/widget -I../src/widget -Idata -I/app/include/chcase -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/gtk-4.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glycin-2 -I/usr/include/cairo -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/graphene-1.0 -I/usr/lib/x86_64-linux-gnu/graphene-1.0/include -I/usr/include/gtksourceview-5 -I/usr/include/libxml2 -I/usr/include/libadwaita-1 -I/usr/include/appstream -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu11 -O0 -g -Wcast-align -Wdeclaration-after-statement -Werror=address -Werror=array-bounds -Werror=empty-body -Werror=implicit -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=init-self -Werror=int-conversion -Werror=int-to-pointer-cast -Werror=main -Werror=misleading-indentation -Werror=missing-braces -Werror=missing-include-dirs -Werror=nonnull -Werror=overflow -Werror=parentheses -Werror=pointer-arith -Werror=pointer-to-int-cast -Werror=redundant-decls -Werror=return-type -Werror=sequence-point -Werror=shadow -Werror=strict-prototypes -Werror=trigraphs -Werror=undef -Werror=write-strings -Wformat-nonliteral -Wformat-signedness -Wignored-qualifiers -Wimplicit-function-declaration -Wlogical-op -Wmaybe-uninitialized -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wnested-externs -Wno-cast-function-type -Wno-dangling-pointer -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-default -Wundef -Wuninitialized -Wunused -fno-strict-aliasing -Werror=format-security -Werror=format=2 -fstack-protector-strong -O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mfpmath=sse -msse -msse2 -pthread -mfpmath=sse -msse -msse2 -mfpmath=sse -msse -msse2 -MD -MQ src/com.github.ryonakano.konbucase.Devel.p/widget_kc-text-area.c.o -MF src/com.github.ryonakano.konbucase.Devel.p/widget_kc-text-area.c.o.d -o src/com.github.ryonakano.konbucase.Devel.p/widget_kc-text-area.c.o -c ../src/widget/kc-text-area.c
cc1: error: /app/include/chcase: No such file or directory [-Werror=missing-include-dirs]
cc1: some warnings being treated as errors
```